### PR TITLE
fix: correct YRangeCursorTool annotation when cursors are inverted

### DIFF
--- a/datalab/gui/docks.py
+++ b/datalab/gui/docks.py
@@ -94,8 +94,8 @@ class CurveStatsToolFunctions:
             )
         else:  # YRangeCursorTool
             labelfuncs = (
-                ("%g &lt; y &lt; %g", lambda ymin, ymax: (ymin, ymax)),
-                ("∆y=%g", lambda ymin, ymax: ymax - ymin),
+                ("%g &lt; y &lt; %g", lambda ymin, ymax: (min(ymin, ymax), max(ymin, ymax))),
+                ("∆y=%g", lambda ymin, ymax: abs(ymax - ymin)),
             )
         statstool.set_labelfuncs(labelfuncs)
 


### PR DESCRIPTION
## Summary

Fixes #306

When the top Y-range cursor is dragged below the bottom cursor (`ymin > ymax`), the annotation label showed an invalid inequality (e.g. `5 < y < 2`) and a negative delta value (`∆y=-3`).

## Changes

In `datalab/gui/docks.py` → `CurveStatsToolFunctions.set_labelfuncs()`:

- **Line 97:** Use `min(ymin, ymax)` / `max(ymin, ymax)` to always display the smaller value on the left
- **Line 98:** Use `abs(ymax - ymin)` so delta is always positive

## Test Plan

- [x] Verified the fix logic: `min()/max()` ensures correct ordering, `abs()` ensures positive delta
- [ ] Manual test: drag top cursor below bottom cursor, verify annotation shows valid inequality and positive delta