### PR TITLE
FIX: Refreshes plot defaults on theme switch

### DIFF
--- a/datalab/gui/main.py
+++ b/datalab/gui/main.py
@@ -57,6 +57,8 @@ from datalab.config import (
     APP_NAME,
     DATAPATH,
     DEBUG,
+    PLOTPY_CONF,
+    PLOTPY_DEFAULTS,
     TEST_SEGFAULT_ERROR,
     Conf,
     _,
@@ -2416,6 +2418,7 @@ class DLMainWindow(  # pylint: disable=too-many-instance-attributes,too-many-pub
         self.setUpdatesEnabled(False)
 
         plotpy_config.set_plotpy_color_mode(mode)
+        PLOTPY_CONF.update_defaults(PLOTPY_DEFAULTS)
 
         if self.console is not None:
             self.console.update_color_mode()


### PR DESCRIPTION
close #297 

Ensures plotting settings are reapplied when the color mode changes.

Keeps plot appearance consistent with the active theme instead of leaving stale default settings in place.